### PR TITLE
Fix Settings attribute error when previews are disabled 

### DIFF
--- a/py/settings.py
+++ b/py/settings.py
@@ -6,6 +6,8 @@ from pathlib import Path
 class Settings:
     def __init__(self):
         self.btp_enabled = False
+        self.btp_publish_last_preview = False
+        self.btp_publish_last_preview_min_refresh = 5
 
     def update(self, obj):
         btp = obj.get("betterTaesdPreviews", None)


### PR DESCRIPTION
Referring to this:
`AttributeError: 'Settings' object has no attribute 'btp_publish_last_preview'`

The bug from [issue](https://github.com/blepping/ComfyUI-bleh/issues/38) #38 still occurs when a config file exists but explicitly disables previews, as btp_publish_last_preview is only initialized in the "enabled" path.

The fallback in this [commit ](https://github.com/blepping/ComfyUI-bleh/commit/14db3017160e0b7680173c4e8cc5e86a60b55fa2) only handles the case where there is no config.

Initialize the preview-related settings in __init__ so the Settings object always has those attributes, even when previews are turned off. 



